### PR TITLE
[Feat]: Extract navigation logic from ViewController to coordinator

### DIFF
--- a/PodcastPlayer.xcodeproj/project.pbxproj
+++ b/PodcastPlayer.xcodeproj/project.pbxproj
@@ -8,6 +8,8 @@
 
 /* Begin PBXBuildFile section */
 		0DD4901829A60D15007AC66E /* PodcastFeedViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DD4901729A60D15007AC66E /* PodcastFeedViewControllerFactory.swift */; };
+		0DD4901B29A61F59007AC66E /* Coordinating.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DD4901A29A61F59007AC66E /* Coordinating.swift */; };
+		0DD4901D29A61F8F007AC66E /* PodcastFeedCoordinator.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DD4901C29A61F8F007AC66E /* PodcastFeedCoordinator.swift */; };
 		5B507977B11368B117CD7FB5 /* Pods_PodcastPlayer_PodcastPlayerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92A39518460425BF0D571196 /* Pods_PodcastPlayer_PodcastPlayerUITests.framework */; };
 		710DDE4E25FCA79700CFF133 /* PlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710DDE4D25FCA79700CFF133 /* PlayerViewModel.swift */; };
 		710DDED125FE551000CFF133 /* AVPlayerItem+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710DDED025FE551000CFF133 /* AVPlayerItem+Extension.swift */; };
@@ -88,6 +90,8 @@
 /* Begin PBXFileReference section */
 		0B700F3272DD8AC5D43BE7F9 /* Pods_PodcastPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PodcastPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		0DD4901729A60D15007AC66E /* PodcastFeedViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastFeedViewControllerFactory.swift; sourceTree = "<group>"; };
+		0DD4901A29A61F59007AC66E /* Coordinating.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Coordinating.swift; sourceTree = "<group>"; };
+		0DD4901C29A61F8F007AC66E /* PodcastFeedCoordinator.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastFeedCoordinator.swift; sourceTree = "<group>"; };
 		0F1BB758FF437D4D82629DCD /* Pods-PodcastPlayerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PodcastPlayerTests.debug.xcconfig"; path = "Target Support Files/Pods-PodcastPlayerTests/Pods-PodcastPlayerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4F4C0986976B55A4A3CFB6ED /* Pods-PodcastPlayer-PodcastPlayerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PodcastPlayer-PodcastPlayerUITests.release.xcconfig"; path = "Target Support Files/Pods-PodcastPlayer-PodcastPlayerUITests/Pods-PodcastPlayer-PodcastPlayerUITests.release.xcconfig"; sourceTree = "<group>"; };
 		710DDE4D25FCA79700CFF133 /* PlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewModel.swift; sourceTree = "<group>"; };
@@ -201,6 +205,15 @@
 				0DD4901729A60D15007AC66E /* PodcastFeedViewControllerFactory.swift */,
 			);
 			path = Factories;
+			sourceTree = "<group>";
+		};
+		0DD4901929A61F48007AC66E /* Coordinators */ = {
+			isa = PBXGroup;
+			children = (
+				0DD4901A29A61F59007AC66E /* Coordinating.swift */,
+				0DD4901C29A61F8F007AC66E /* PodcastFeedCoordinator.swift */,
+			);
+			path = Coordinators;
 			sourceTree = "<group>";
 		};
 		4D7982D1D414885881F8762D /* Frameworks */ = {
@@ -415,6 +428,7 @@
 		7183AAC025E764A300E1AD98 /* PodcastPlayer */ = {
 			isa = PBXGroup;
 			children = (
+				0DD4901929A61F48007AC66E /* Coordinators */,
 				0DD4901629A60CC1007AC66E /* Factories */,
 				71AE977A25EBF8A100E9284F /* Helper */,
 				713D496925EB717400058FD4 /* Extension */,
@@ -878,6 +892,7 @@
 				718C9D8E25ECD20A00B864E4 /* HomeXMLParser.swift in Sources */,
 				712674A225FBC58B0080D9B3 /* HomepageViewModel.swift in Sources */,
 				71AE978125EBF95100E9284F /* UITableViewCell+Extension.swift in Sources */,
+				0DD4901B29A61F59007AC66E /* Coordinating.swift in Sources */,
 				71AE977625EBCBDB00E9284F /* UINavigationController+Extension.swift in Sources */,
 				7189CEC125EE2E8100434D6C /* AVPlayerManager.swift in Sources */,
 				716B645025F0D3C800032560 /* EpisodeFeedLoader.swift in Sources */,
@@ -885,6 +900,7 @@
 				712674AF25FC5ED90080D9B3 /* EpisodeViewModel.swift in Sources */,
 				7183AAC225E764A300E1AD98 /* AppDelegate.swift in Sources */,
 				713D496B25EB719700058FD4 /* UITableView+Extension.swift in Sources */,
+				0DD4901D29A61F8F007AC66E /* PodcastFeedCoordinator.swift in Sources */,
 				710DDE4E25FCA79700CFF133 /* PlayerViewModel.swift in Sources */,
 				7165B70925ECE3F900D3A79D /* UIImage+Extension.swift in Sources */,
 				71CFF16E25EA4D6900C0D278 /* URLSessionHTTPClient.swift in Sources */,

--- a/PodcastPlayer.xcodeproj/project.pbxproj
+++ b/PodcastPlayer.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		0DD4901829A60D15007AC66E /* PodcastFeedViewControllerFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = 0DD4901729A60D15007AC66E /* PodcastFeedViewControllerFactory.swift */; };
 		5B507977B11368B117CD7FB5 /* Pods_PodcastPlayer_PodcastPlayerUITests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 92A39518460425BF0D571196 /* Pods_PodcastPlayer_PodcastPlayerUITests.framework */; };
 		710DDE4E25FCA79700CFF133 /* PlayerViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710DDE4D25FCA79700CFF133 /* PlayerViewModel.swift */; };
 		710DDED125FE551000CFF133 /* AVPlayerItem+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = 710DDED025FE551000CFF133 /* AVPlayerItem+Extension.swift */; };
@@ -86,6 +87,7 @@
 
 /* Begin PBXFileReference section */
 		0B700F3272DD8AC5D43BE7F9 /* Pods_PodcastPlayer.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_PodcastPlayer.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		0DD4901729A60D15007AC66E /* PodcastFeedViewControllerFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PodcastFeedViewControllerFactory.swift; sourceTree = "<group>"; };
 		0F1BB758FF437D4D82629DCD /* Pods-PodcastPlayerTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PodcastPlayerTests.debug.xcconfig"; path = "Target Support Files/Pods-PodcastPlayerTests/Pods-PodcastPlayerTests.debug.xcconfig"; sourceTree = "<group>"; };
 		4F4C0986976B55A4A3CFB6ED /* Pods-PodcastPlayer-PodcastPlayerUITests.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-PodcastPlayer-PodcastPlayerUITests.release.xcconfig"; path = "Target Support Files/Pods-PodcastPlayer-PodcastPlayerUITests/Pods-PodcastPlayer-PodcastPlayerUITests.release.xcconfig"; sourceTree = "<group>"; };
 		710DDE4D25FCA79700CFF133 /* PlayerViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PlayerViewModel.swift; sourceTree = "<group>"; };
@@ -193,6 +195,14 @@
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		0DD4901629A60CC1007AC66E /* Factories */ = {
+			isa = PBXGroup;
+			children = (
+				0DD4901729A60D15007AC66E /* PodcastFeedViewControllerFactory.swift */,
+			);
+			path = Factories;
+			sourceTree = "<group>";
+		};
 		4D7982D1D414885881F8762D /* Frameworks */ = {
 			isa = PBXGroup;
 			children = (
@@ -405,6 +415,7 @@
 		7183AAC025E764A300E1AD98 /* PodcastPlayer */ = {
 			isa = PBXGroup;
 			children = (
+				0DD4901629A60CC1007AC66E /* Factories */,
 				71AE977A25EBF8A100E9284F /* Helper */,
 				713D496925EB717400058FD4 /* Extension */,
 				71C049B325F48FBF00ACBA4C /* Networking */,
@@ -879,6 +890,7 @@
 				71CFF16E25EA4D6900C0D278 /* URLSessionHTTPClient.swift in Sources */,
 				7189CEEF25EFE48100434D6C /* UIColor+Extension.swift in Sources */,
 				712CB91325E9E72600034CE7 /* RemoteEpisodeFeedLoader.swift in Sources */,
+				0DD4901829A60D15007AC66E /* PodcastFeedViewControllerFactory.swift in Sources */,
 				7183AAC425E764A300E1AD98 /* SceneDelegate.swift in Sources */,
 				7162BB6425F507E9006DD513 /* EpisodeFeedItem.m in Sources */,
 				7189CE8925ED390200434D6C /* HTTPClient.swift in Sources */,

--- a/PodcastPlayer/Coordinators/Coordinating.swift
+++ b/PodcastPlayer/Coordinators/Coordinating.swift
@@ -1,0 +1,12 @@
+//
+//  Coordinating.swift
+//  PodcastPlayer
+//
+//  Created by JiaSin Liu on 2023/2/22.
+//
+
+import Foundation
+
+protocol Coordinating {
+    func start()
+}

--- a/PodcastPlayer/Coordinators/PodcastFeedCoordinator.swift
+++ b/PodcastPlayer/Coordinators/PodcastFeedCoordinator.swift
@@ -10,6 +10,7 @@ import UIKit
 final class PodcastFeedCoordinator: Coordinating {
     
     typealias MakeHomeViewController = (URL, @escaping (([Episode], Int) -> Void)) -> UIViewController
+    
     private let navigationViewController: UINavigationController
     private let makeHomeViewController: MakeHomeViewController
     private let homePageUrl: URL
@@ -31,8 +32,16 @@ final class PodcastFeedCoordinator: Coordinating {
     
     func tapOnEpisode(episodes: [Episode], currentPage: Int) {
         let episodeViewController = PodcastFeedViewControllerFactory.makeEpisodePageViewController(episodes: episodes,
-                                                                                                   currenPage: currentPage)
+                                                                                                   currenPage: currentPage,
+                                                                                                   onTapPlay: { [weak self] (episodes, page, playingEpisode) in
+            self?.tapOnPlay(episodes: episodes, currentPage: page, playingEpisode: playingEpisode)
+        })
         navigationViewController.pushViewController(episodeViewController, animated: true)
+    }
+    
+    func tapOnPlay(episodes: [Episode], currentPage: Int, playingEpisode: @escaping (Episode) -> Void) {
+        let playerVC = PodcastFeedViewControllerFactory.makePlayerViewController(episodes: episodes, currentPage: currentPage, updateEpisode: playingEpisode)
+        navigationViewController.present(playerVC, animated: true)
     }
 }
 

--- a/PodcastPlayer/Coordinators/PodcastFeedCoordinator.swift
+++ b/PodcastPlayer/Coordinators/PodcastFeedCoordinator.swift
@@ -9,17 +9,30 @@ import UIKit
 
 final class PodcastFeedCoordinator: Coordinating {
     
+    typealias MakeHomeViewController = (URL, @escaping (([Episode], Int) -> Void)) -> UIViewController
     private let navigationViewController: UINavigationController
-    private let makeHomepageViewController: UIViewController
+    private let makeHomeViewController: MakeHomeViewController
+    private let homePageUrl: URL
     
     init(navigationController: UINavigationController,
-         makeHomepageViewController: UIViewController) {
+         makeHomepageViewController: @escaping MakeHomeViewController,
+         homePageUrl: URL) {
         self.navigationViewController = navigationController
-        self.makeHomepageViewController = makeHomepageViewController
+        self.makeHomeViewController = makeHomepageViewController
+        self.homePageUrl = homePageUrl
     }
     
     func start() {
-        navigationViewController.setViewControllers([makeHomepageViewController], animated: false)
+        navigationViewController.setViewControllers([
+            makeHomeViewController(homePageUrl) { [weak self] episodes, index in
+            self?.tapOnEpisode(episodes: episodes, currentPage: index)
+        }], animated: false)
+    }
+    
+    func tapOnEpisode(episodes: [Episode], currentPage: Int) {
+        let episodeViewController = PodcastFeedViewControllerFactory.makeEpisodePageViewController(episodes: episodes,
+                                                                                                   currenPage: currentPage)
+        navigationViewController.pushViewController(episodeViewController, animated: true)
     }
 }
 

--- a/PodcastPlayer/Coordinators/PodcastFeedCoordinator.swift
+++ b/PodcastPlayer/Coordinators/PodcastFeedCoordinator.swift
@@ -1,0 +1,25 @@
+//
+//  PodcastFeedCoordinator.swift
+//  PodcastPlayer
+//
+//  Created by JiaSin Liu on 2023/2/22.
+//
+
+import UIKit
+
+final class PodcastFeedCoordinator: Coordinating {
+    
+    private let navigationViewController: UINavigationController
+    private let makeHomepageViewController: UIViewController
+    
+    init(navigationController: UINavigationController,
+         makeHomepageViewController: UIViewController) {
+        self.navigationViewController = navigationController
+        self.makeHomepageViewController = makeHomepageViewController
+    }
+    
+    func start() {
+        navigationViewController.setViewControllers([makeHomepageViewController], animated: false)
+    }
+}
+

--- a/PodcastPlayer/Episode/Controller/EpisodeViewController.swift
+++ b/PodcastPlayer/Episode/Controller/EpisodeViewController.swift
@@ -33,13 +33,11 @@ public final class EpisodeViewController: UIViewController {
     @IBAction func pressPlay(_ sender: UIButton) {
         guard let episodes = viewModel?.episodes, let index = viewModel?.currentEpisodeIndex else { return }
         
-        let playerModel = PlayerModel(episodes: episodes, currentIndex: index)
-        
-        let playerViewController = PlayerViewController(playerModel: playerModel)
-        
-        playerViewController.updateEpisode = { [weak self] (episode) in
-            self?.viewModel?.update(episode: episode)
-        }
+        let playerViewController = PodcastFeedViewControllerFactory.makePlayerViewController(episodes: episodes,
+                                                                                             currentPage: index,
+                                                                                             updateEpisode: { [weak viewModel] (episode) in
+            viewModel?.update(episode: episode)
+        })
                         
         present(playerViewController, animated: true)
     }

--- a/PodcastPlayer/Episode/Controller/EpisodeViewController.swift
+++ b/PodcastPlayer/Episode/Controller/EpisodeViewController.swift
@@ -14,14 +14,21 @@ public final class EpisodeViewController: UIViewController {
     @IBOutlet weak var descriptionTextView: UITextView!
     @IBOutlet weak var playButton: UIButton!
     
+    private let updateEpisode: ([Episode], Int, @escaping (Episode) -> Void) -> Void
     private var viewModel: EpisodeViewModel?
     
-    convenience init(episodes: [Episode], currentEpisodeIndex: Int) {
-        self.init()
-
-        viewModel = EpisodeViewModel(epiosdes: episodes, at: currentEpisodeIndex)
+    init(episodes: [Episode],
+         currentEpisodeIndex: Int,
+         onTapPaly: @escaping ([Episode], Int, @escaping (Episode) -> Void) -> Void) {
+        self.viewModel = EpisodeViewModel(epiosdes: episodes, at: currentEpisodeIndex)
+        self.updateEpisode = onTapPaly
+        super.init(nibName: nil, bundle: nil)
     }
-        
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+    
     public override func viewDidLoad() {
         super.viewDidLoad()
 
@@ -32,14 +39,9 @@ public final class EpisodeViewController: UIViewController {
     
     @IBAction func pressPlay(_ sender: UIButton) {
         guard let episodes = viewModel?.episodes, let index = viewModel?.currentEpisodeIndex else { return }
-        
-        let playerViewController = PodcastFeedViewControllerFactory.makePlayerViewController(episodes: episodes,
-                                                                                             currentPage: index,
-                                                                                             updateEpisode: { [weak viewModel] (episode) in
+        updateEpisode(episodes, index) { [viewModel] (episode) in
             viewModel?.update(episode: episode)
-        })
-                        
-        present(playerViewController, animated: true)
+        }
     }
 }
 

--- a/PodcastPlayer/Episode/ViewModel/EpisodeViewModel.swift
+++ b/PodcastPlayer/Episode/ViewModel/EpisodeViewModel.swift
@@ -19,11 +19,16 @@ public final class EpisodeViewModel {
         self.currentEpisodeIndex = index
     }
     
-    public func update(to newIndex: Int) {
-        self.currentEpisodeIndex = newIndex
-    }
-    
     public func update(episode: Episode) {
         self.episodesViewModel.value = episode
+        //TODO: Update currentEpisodeIndex's method need to be refactored
+        if let index = episodes.firstIndex(where: { $0.title == episode.title }),
+        currentEpisodeIndex == index {
+            update(to: index)
+        }
+    }
+    
+    private func update(to newIndex: Int) {
+        self.currentEpisodeIndex = newIndex
     }
 }

--- a/PodcastPlayer/Extension/UIViewController+Extension.swift
+++ b/PodcastPlayer/Extension/UIViewController+Extension.swift
@@ -12,8 +12,6 @@ extension UIViewController {
         let alert = UIAlertController(title: title, message: message, preferredStyle: .alert)
         
         actions.forEach { alert.addAction($0) }
-//        let action = UIAlertAction(title: actionTitle, style: .cancel, handler: <#T##((UIAlertAction) -> Void)?##((UIAlertAction) -> Void)?##(UIAlertAction) -> Void#>)
-//        alert.addAction(action)
         present(alert, animated: true, completion: nil)
     }
 }

--- a/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
+++ b/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
@@ -9,8 +9,7 @@ import UIKit
 
 class PodcastFeedViewControllerFactory {
     
-    static func makeHomepageViewController() -> UIViewController {
-        let url = URL(string: "https://feeds.soundcloud.com/users/soundcloud:users:322164009/sounds.rss")!
+    static func makeHomepageViewController(url: URL) -> UIViewController {
         let remoteFeedLoader = RemoteEpisodeFeedLoader(client: URLSessionHTTPClient(), url: url)
         let homeViewController = HomepageViewController(loader: remoteFeedLoader)
         return homeViewController

--- a/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
+++ b/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
@@ -9,14 +9,16 @@ import UIKit
 
 class PodcastFeedViewControllerFactory {
     
-    static func makeHomepageViewController(url: URL) -> UIViewController {
+    static func makeHomepageViewController(url: URL,
+                                           tapOnEpisode: @escaping (([Episode], Int) -> Void)) -> UIViewController {
         let remoteFeedLoader = RemoteEpisodeFeedLoader(client: URLSessionHTTPClient(), url: url)
-        let homeViewController = HomepageViewController(loader: remoteFeedLoader)
+        let homeViewController = HomepageViewController(loader: remoteFeedLoader, tapOnEpisode: tapOnEpisode)
         return homeViewController
     }
     
     static func makeEpisodePageViewController(episodes: [Episode], currenPage: Int) -> UIViewController {
-        let episodeViewController = EpisodeViewController(episodes: episodes, currentEpisodeIndex: currenPage)
+        let episodeViewController = EpisodeViewController(episodes: episodes,
+                                                          currentEpisodeIndex: currenPage)
         return episodeViewController
     }
     

--- a/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
+++ b/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
@@ -16,9 +16,12 @@ class PodcastFeedViewControllerFactory {
         return homeViewController
     }
     
-    static func makeEpisodePageViewController(episodes: [Episode], currenPage: Int) -> UIViewController {
+    static func makeEpisodePageViewController(episodes: [Episode],
+                                              currenPage: Int,
+                                              onTapPlay: @escaping ([Episode], Int, @escaping (Episode) -> Void) -> Void) -> UIViewController {
         let episodeViewController = EpisodeViewController(episodes: episodes,
-                                                          currentEpisodeIndex: currenPage)
+                                                          currentEpisodeIndex: currenPage,
+                                                          onTapPaly: onTapPlay)
         return episodeViewController
     }
     
@@ -26,8 +29,8 @@ class PodcastFeedViewControllerFactory {
                                          currentPage: Int,
                                          updateEpisode: @escaping (Episode) -> Void) -> UIViewController {
         let playerModel = PlayerModel(episodes: episodes, currentIndex: currentPage)
-        let playerViewController = PlayerViewController(playerModel: playerModel)
-        playerViewController.updateEpisode = updateEpisode
+        let playerViewController = PlayerViewController(playerModel: playerModel,
+                                                        updateEpisode: updateEpisode)
         return playerViewController
     }
 }

--- a/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
+++ b/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
@@ -15,4 +15,9 @@ class PodcastFeedViewControllerFactory {
         let homeViewController = HomepageViewController(loader: remoteFeedLoader)
         return homeViewController
     }
+    
+    static func makeEpisodePageViewController(episodes: [Episode], currenPage: Int) -> UIViewController {
+        let episodeViewController = EpisodeViewController(episodes: episodes, currentEpisodeIndex: currenPage)
+        return episodeViewController
+    }
 }

--- a/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
+++ b/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
@@ -27,10 +27,14 @@ class PodcastFeedViewControllerFactory {
     
     static func makePlayerViewController(episodes: [Episode],
                                          currentPage: Int,
-                                         updateEpisode: @escaping (Episode) -> Void) -> UIViewController {
+                                         updateEpisode: @escaping (Episode) -> Void,
+                                         failOnLoadingSoundtrack: @escaping () -> Void,
+                                         cannotFindEpisode: @escaping ( (PlayerViewController.TouchEvent) -> Void)) -> UIViewController {
         let playerModel = PlayerModel(episodes: episodes, currentIndex: currentPage)
         let playerViewController = PlayerViewController(playerModel: playerModel,
-                                                        updateEpisode: updateEpisode)
+                                                        updateEpisode: updateEpisode,
+                                                        failOnLoadingSoundtrack: failOnLoadingSoundtrack,
+                                                        cannotFindEpisode: cannotFindEpisode)
         return playerViewController
     }
 }

--- a/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
+++ b/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
@@ -20,4 +20,13 @@ class PodcastFeedViewControllerFactory {
         let episodeViewController = EpisodeViewController(episodes: episodes, currentEpisodeIndex: currenPage)
         return episodeViewController
     }
+    
+    static func makePlayerViewController(episodes: [Episode],
+                                         currentPage: Int,
+                                         updateEpisode: @escaping (Episode) -> Void) -> UIViewController {
+        let playerModel = PlayerModel(episodes: episodes, currentIndex: currentPage)
+        let playerViewController = PlayerViewController(playerModel: playerModel)
+        playerViewController.updateEpisode = updateEpisode
+        return playerViewController
+    }
 }

--- a/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
+++ b/PodcastPlayer/Factories/PodcastFeedViewControllerFactory.swift
@@ -1,0 +1,18 @@
+//
+//  PodcastFeedViewControllerFactory.swift
+//  PodcastPlayer
+//
+//  Created by JiaSin Liu on 2023/2/22.
+//
+
+import UIKit
+
+class PodcastFeedViewControllerFactory {
+    
+    static func makeHomepageViewController() -> UIViewController {
+        let url = URL(string: "https://feeds.soundcloud.com/users/soundcloud:users:322164009/sounds.rss")!
+        let remoteFeedLoader = RemoteEpisodeFeedLoader(client: URLSessionHTTPClient(), url: url)
+        let homeViewController = HomepageViewController(loader: remoteFeedLoader)
+        return homeViewController
+    }
+}

--- a/PodcastPlayer/Fundmental/SceneDelegate.swift
+++ b/PodcastPlayer/Fundmental/SceneDelegate.swift
@@ -10,6 +10,9 @@ import UIKit
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 
     var window: UIWindow?
+    lazy var navigationController = makeNavigationController()
+    lazy var coordinator = PodcastFeedCoordinator(navigationController: navigationController,
+                                                  makeHomepageViewController: makeRootViewController())
 
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
@@ -20,39 +23,18 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         
         window?.makeKeyAndVisible()
-        let nav = UINavigationController(rootViewController: PodcastFeedViewControllerFactory.makeHomepageViewController())
+        window?.rootViewController = navigationController
+        coordinator.start()
+    }
+    
+    private func makeRootViewController() -> UIViewController {
+        return PodcastFeedViewControllerFactory.makeHomepageViewController(url: URL(string: "https://feeds.soundcloud.com/users/soundcloud:users:322164009/sounds.rss")!)
+    }
+    
+    private func makeNavigationController() -> UINavigationController {
+        let nav = UINavigationController()
         nav.navigationBar.tintColor = .black
-        window?.rootViewController = nav
+        return nav
     }
-
-    func sceneDidDisconnect(_ scene: UIScene) {
-        // Called as the scene is being released by the system.
-        // This occurs shortly after the scene enters the background, or when its session is discarded.
-        // Release any resources associated with this scene that can be re-created the next time the scene connects.
-        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
-    }
-
-    func sceneDidBecomeActive(_ scene: UIScene) {
-        // Called when the scene has moved from an inactive state to an active state.
-        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
-    }
-
-    func sceneWillResignActive(_ scene: UIScene) {
-        // Called when the scene will move from an active state to an inactive state.
-        // This may occur due to temporary interruptions (ex. an incoming phone call).
-    }
-
-    func sceneWillEnterForeground(_ scene: UIScene) {
-        // Called as the scene transitions from the background to the foreground.
-        // Use this method to undo the changes made on entering the background.
-    }
-
-    func sceneDidEnterBackground(_ scene: UIScene) {
-        // Called as the scene transitions from the foreground to the background.
-        // Use this method to save data, release shared resources, and store enough scene-specific state information
-        // to restore the scene back to its current state.
-    }
-
-
 }
 

--- a/PodcastPlayer/Fundmental/SceneDelegate.swift
+++ b/PodcastPlayer/Fundmental/SceneDelegate.swift
@@ -8,12 +8,13 @@
 import UIKit
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
-
+    
     var window: UIWindow?
     lazy var navigationController = makeNavigationController()
     lazy var coordinator = PodcastFeedCoordinator(navigationController: navigationController,
-                                                  makeHomepageViewController: makeRootViewController())
-
+                                                  makeHomepageViewController: PodcastFeedViewControllerFactory.makeHomepageViewController(url:tapOnEpisode:),
+                                                  homePageUrl: URL(string: "https://feeds.soundcloud.com/users/soundcloud:users:322164009/sounds.rss")!)
+    
     func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
         // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
         // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
@@ -25,10 +26,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window?.makeKeyAndVisible()
         window?.rootViewController = navigationController
         coordinator.start()
-    }
-    
-    private func makeRootViewController() -> UIViewController {
-        return PodcastFeedViewControllerFactory.makeHomepageViewController(url: URL(string: "https://feeds.soundcloud.com/users/soundcloud:users:322164009/sounds.rss")!)
     }
     
     private func makeNavigationController() -> UINavigationController {

--- a/PodcastPlayer/Fundmental/SceneDelegate.swift
+++ b/PodcastPlayer/Fundmental/SceneDelegate.swift
@@ -20,12 +20,7 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
         window = UIWindow(windowScene: windowScene)
         
         window?.makeKeyAndVisible()
-        
-        let url = URL(string: "https://feeds.soundcloud.com/users/soundcloud:users:322164009/sounds.rss")!
-
-        let remoteFeedLoader = RemoteEpisodeFeedLoader(client: URLSessionHTTPClient(), url: url)
-        let homeViewController = HomepageViewController(loader: remoteFeedLoader)
-        let nav = UINavigationController(rootViewController: homeViewController)
+        let nav = UINavigationController(rootViewController: PodcastFeedViewControllerFactory.makeHomepageViewController())
         nav.navigationBar.tintColor = .black
         window?.rootViewController = nav
     }

--- a/PodcastPlayer/Home/Controller/HomepageViewController.swift
+++ b/PodcastPlayer/Home/Controller/HomepageViewController.swift
@@ -82,7 +82,8 @@ extension HomepageViewController: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
         guard let episodes = viewModel?.feed?.episodes as? [Episode], !episodes.isEmpty else { return }
         
-        let episodeViewController = EpisodeViewController(episodes: episodes, currentEpisodeIndex: indexPath.row)
+        let episodeViewController = PodcastFeedViewControllerFactory.makeEpisodePageViewController(episodes: episodes,
+                                                                                                   currenPage: indexPath.row)
 
         navigationController?.pushViewController(episodeViewController, animated: true)
         

--- a/PodcastPlayer/Home/Controller/HomepageViewController.swift
+++ b/PodcastPlayer/Home/Controller/HomepageViewController.swift
@@ -14,8 +14,9 @@ public final class HomepageViewController: UIViewController {
 
     @IBOutlet weak var tableView: UITableView!
     
+    private let tapOnEpisode: (([Episode], Int) -> Void)
     private var loader: EpisodeFeedLoader?
-    private var viewModel: VideModel?
+    private var viewModel: VideModel
     
     private lazy var headerView: HomepageTableHeaderView = {
         let headerView = HomepageTableHeaderView(frame: .zero)
@@ -28,9 +29,15 @@ public final class HomepageViewController: UIViewController {
 
 	private static let tableHeaderHeight: CGFloat = 160.0
     
-    public convenience init(loader: EpisodeFeedLoader){
-        self.init()
+    init(loader: EpisodeFeedLoader,
+         tapOnEpisode: @escaping (([Episode], Int) -> Void)) {
         self.viewModel = HomepageViewModel(loader: loader)
+        self.tapOnEpisode = tapOnEpisode
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     public override func viewDidLoad() {
@@ -43,7 +50,7 @@ public final class HomepageViewController: UIViewController {
 
 private extension HomepageViewController {
     func load() {
-        viewModel?.load()
+        viewModel.load()
     }
     
     func setupTableView() {
@@ -57,19 +64,19 @@ private extension HomepageViewController {
     }
     
     func viewModelDataBinding() {
-        viewModel?.refreshData = { [weak self] in
+        viewModel.refreshData = { [weak self] in
             DispatchQueue.main.async {
                 self?.tableView.reloadData()
             }
         }
         
-        viewModel?.configureHeaderView = { [weak self] (imageURL) in
+        viewModel.configureHeaderView = { [weak self] (imageURL) in
             DispatchQueue.main.async {
                 self?.headerView.configure(with: imageURL)
             }
         }
         
-        viewModel?.handleError = { [weak self] (error) in
+        viewModel.handleError = { [weak self] (error) in
             DispatchQueue.main.async {
                 let confirmAction = UIAlertAction(title: "確認", style: .default)
                 self?.popAlert(title: "錯誤", message: "\(error)", actions: [confirmAction])
@@ -80,20 +87,15 @@ private extension HomepageViewController {
 
 extension HomepageViewController: UITableViewDelegate {
     public func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
-        guard let episodes = viewModel?.feed?.episodes as? [Episode], !episodes.isEmpty else { return }
-        
-        let episodeViewController = PodcastFeedViewControllerFactory.makeEpisodePageViewController(episodes: episodes,
-                                                                                                   currenPage: indexPath.row)
-
-        navigationController?.pushViewController(episodeViewController, animated: true)
-        
+        guard let episodes = viewModel.feed?.episodes as? [Episode], !episodes.isEmpty else { return }
+        tapOnEpisode(episodes, indexPath.row)
         tableView.deselectRow(at: indexPath, animated: true)
     }
 }
 
 extension HomepageViewController: UITableViewDataSource {
     public func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-        return viewModel?.feed?.episodes.count ?? 0
+        return viewModel.feed?.episodes.count ?? 0
     }
     
     public func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
@@ -103,7 +105,7 @@ extension HomepageViewController: UITableViewDataSource {
     public func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
         let cell: EpisodeFeedTableViewCell = tableView.makeCell(with: EpisodeFeedTableViewCell.reuseIdentifier, for: indexPath)
         
-        if let cellModel = try? viewModel?.getEpisode(at: indexPath.row) {
+        if let cellModel = try? viewModel.getEpisode(at: indexPath.row) {
             cell.render(with: cellModel)
         }
         

--- a/PodcastPlayer/Home/Model/EpisodeFeed/RemoteEpisodeFeedLoader.swift
+++ b/PodcastPlayer/Home/Model/EpisodeFeed/RemoteEpisodeFeedLoader.swift
@@ -31,7 +31,6 @@ public final class RemoteEpisodeFeedLoader: EpisodeFeedLoader {
             switch result {
             case let .success((data, response)):
                 // - MARK: 我想得到 .success(decoded data) 或 .failure(RemoteFeedLoader.Error)。這邊讓 private function map 處理
-                
                 completion(self.map(data: data, response: response))
             case .failure(_):
                 completion(.failure(Error.connectivityError))
@@ -39,7 +38,7 @@ public final class RemoteEpisodeFeedLoader: EpisodeFeedLoader {
         }
     }
 }
-// 去跑 FeedMapper 的 data,response 處理
+
 extension RemoteEpisodeFeedLoader {
     private func map(data: Data, response: HTTPURLResponse) -> Result {
         do {

--- a/PodcastPlayer/Home/ViewModel/HomepageViewModel.swift
+++ b/PodcastPlayer/Home/ViewModel/HomepageViewModel.swift
@@ -43,6 +43,13 @@ public final class HomepageViewModel: HomepageViewModelOutput {
 }
 // MARK: ViewModel Input:
 extension HomepageViewModel: HomepageViewModelInput {
+    public func tapOnEpisode(at index: Int) -> ([Episode], Int)? {
+        guard let episodes = feed?.episodes as? [Episode], !episodes.isEmpty else {
+            return nil
+        }
+        return (episodes, index)
+    }
+    
 	public func load() {
 		loader?.load(completion: { [weak self] (result) in
 			switch result {

--- a/PodcastPlayer/Player/Controller/PlayerViewController.swift
+++ b/PodcastPlayer/Player/Controller/PlayerViewController.swift
@@ -11,7 +11,11 @@ import Kingfisher
 public final class PlayerViewController: UIViewController {
 
     public typealias AudioPlayable = (PlayPauseProtocol & EpisodeProgressTracking & EpisodeSoundLoader)
-    public let updateEpisode: (Episode) -> Void
+    public typealias TouchEvent = PlayerModel.TouchEvent
+    
+    private let updateEpisode: (Episode) -> Void
+    private let failOnLoadingSoundtrack: (() -> Void)
+    private let cannotFindEpisode: ((TouchEvent) -> Void)
     private var viewModel: PlayerViewModel?
     private var audioPlayer: AudioPlayable?
     
@@ -22,10 +26,16 @@ public final class PlayerViewController: UIViewController {
     @IBOutlet weak var previousEPButton: UIButton!
     @IBOutlet weak var slider: UISlider!
     
-    init(audioPlayer: AudioPlayable = AVPlayerManager(), playerModel: EpisodeManipulatible, updateEpisode: @escaping (Episode) -> Void) {
+    init(audioPlayer: AudioPlayable = AVPlayerManager(),
+         playerModel: EpisodeManipulatible,
+         updateEpisode: @escaping (Episode) -> Void,
+         failOnLoadingSoundtrack: @escaping (() -> Void),
+         cannotFindEpisode: @escaping ((TouchEvent) -> Void)) {
         self.audioPlayer = audioPlayer
         self.viewModel = PlayerViewModel(model: playerModel)
         self.updateEpisode = updateEpisode
+        self.failOnLoadingSoundtrack = failOnLoadingSoundtrack
+        self.cannotFindEpisode = cannotFindEpisode
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -143,40 +153,7 @@ extension PlayerViewController {
             self?.audioPlayer?.pause()
         }
         
-        viewModel?.failOnLoadingSoundtrack = { [weak self] in
-            let actions = self?.alertActions(with: .noSoundURL)
-            self?.popAlert(title: "提醒", message: "無法讀取音檔", actions: actions!)
-        }
-        
-        viewModel?.cannotFindEpisode = { [weak self] (event) in
-            let actions = self?.alertActions(with: .indexOutOfRange)
-            
-            switch event {
-            case .checkCurrentProject:
-                self?.popAlert(title: "提醒", message: "當集 Podcast 讀取失敗", actions: actions!)
-            case .checkNextProject:
-                self?.popAlert(title: "提醒", message: "這首已經是最新的 Podcast 了", actions: actions!)
-            case .checkPreviousProject:
-                self?.popAlert(title: "提醒", message: "這首已經是最舊的 Podcast 了", actions: actions!)
-            }
-        }
-    }
-}
-
-// MARK: Alert Handler
-private extension PlayerViewController {
-    func alertActions(with error: PlayerModel.Error) -> [UIAlertAction] {
-        var alertAction: UIAlertAction
-        
-        switch error {
-        case .noSoundURL:
-            alertAction = UIAlertAction(title: "確認", style: .default) { [weak self] (_) in
-                self?.dismiss(animated: true)
-            }
-        case .indexOutOfRange:
-            alertAction = UIAlertAction(title: "確認", style: .default)
-        }
-           
-        return [alertAction]
+        viewModel?.failOnLoadingSoundtrack = failOnLoadingSoundtrack
+        viewModel?.cannotFindEpisode = cannotFindEpisode
     }
 }

--- a/PodcastPlayer/Player/Controller/PlayerViewController.swift
+++ b/PodcastPlayer/Player/Controller/PlayerViewController.swift
@@ -11,7 +11,7 @@ import Kingfisher
 public final class PlayerViewController: UIViewController {
 
     public typealias AudioPlayable = (PlayPauseProtocol & EpisodeProgressTracking & EpisodeSoundLoader)
-    public var updateEpisode: ((Episode) -> Void)?
+    public let updateEpisode: (Episode) -> Void
     private var viewModel: PlayerViewModel?
     private var audioPlayer: AudioPlayable?
     
@@ -22,10 +22,15 @@ public final class PlayerViewController: UIViewController {
     @IBOutlet weak var previousEPButton: UIButton!
     @IBOutlet weak var slider: UISlider!
     
-    public convenience init(audioPlayer: AudioPlayable = AVPlayerManager(), playerModel: EpisodeManipulatible) {
-        self.init()
+    init(audioPlayer: AudioPlayable = AVPlayerManager(), playerModel: EpisodeManipulatible, updateEpisode: @escaping (Episode) -> Void) {
         self.audioPlayer = audioPlayer
         self.viewModel = PlayerViewModel(model: playerModel)
+        self.updateEpisode = updateEpisode
+        super.init(nibName: nil, bundle: nil)
+    }
+    
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
     }
     
     public override func viewDidLoad() {
@@ -41,7 +46,7 @@ public final class PlayerViewController: UIViewController {
         super.viewWillDisappear(animated)
         guard let episode = viewModel?.currentEpisode else { return }
         
-        updateEpisode?(episode)
+        updateEpisode(episode)
         audioPlayer?.resetPlayer()
     }
     


### PR DESCRIPTION
## Behavioral Changes:
- None

## Architectural Changes:
- Extract navigation logic from ViewController to Coordinator
- Extract the initialization of the view controller into a separate class, namely the `PodcastFeedViewControllerFactory`

## Known issues:
- When first enter PlayerViewPage, player couldn't play soundtrack